### PR TITLE
Add i18n support and Spanish support

### DIFF
--- a/src/main/resources/org/juanitodread/conwaygameoflife/i18n/message_es.properties
+++ b/src/main/resources/org/juanitodread/conwaygameoflife/i18n/message_es.properties
@@ -18,15 +18,15 @@
 # */
 
 ## Common
-org.juanitodread.conwaygameoflife.title=Conway's Game of Life
+org.juanitodread.conwaygameoflife.title=Juego de la Vida de Conway
 org.juanitodread.conwaygameoflife.version=v1.2.0
 org.juanitodread.conwaygameoflife.author=@juanitodread
 org.juanitodread.conwaygameoflife.year=2015
 
 ## View
-org.juanitodread.conwaygameoflife.view.startBtn=Start
-org.juanitodread.conwaygameoflife.view.stopBtn=Stop
-org.juanitodread.conwaygameoflife.view.clearBtn=Clear
-org.juanitodread.conwaygameoflife.view.aboutBtn=About
+org.juanitodread.conwaygameoflife.view.startBtn=Iniciar
+org.juanitodread.conwaygameoflife.view.stopBtn=Parar
+org.juanitodread.conwaygameoflife.view.clearBtn=Limpiar
+org.juanitodread.conwaygameoflife.view.aboutBtn=Acerca de
 
-org.juanitodread.conwaygameoflife.view.generationsLbl=Generations
+org.juanitodread.conwaygameoflife.view.generationsLbl=Generaciones

--- a/src/main/scala/org/juanitodread/conwaygameoflife/ApplicationConstants.scala
+++ b/src/main/scala/org/juanitodread/conwaygameoflife/ApplicationConstants.scala
@@ -35,5 +35,14 @@ trait ApplicationConstants {
   val AppTitle = "org.juanitodread.conwaygameoflife.title"
   val AppVersion = "org.juanitodread.conwaygameoflife.version"
   val AppAuthor = "org.juanitodread.conwaygameoflife.author"
+  val AppYear = "org.juanitodread.conwaygameoflife.year"
 
+  val StartButton = "org.juanitodread.conwaygameoflife.view.startBtn"
+  val StopButton = "org.juanitodread.conwaygameoflife.view.stopBtn"
+  val ClearButton = "org.juanitodread.conwaygameoflife.view.clearBtn"
+  val AboutButton = "org.juanitodread.conwaygameoflife.view.aboutBtn"
+
+  val GenerationsLabel = "org.juanitodread.conwaygameoflife.view.generationsLbl"
+
+  val AboutDialog = "org.juanitodread.conwaygameoflife.view.aboutDialog"
 }

--- a/src/main/scala/org/juanitodread/conwaygameoflife/MainApp.scala
+++ b/src/main/scala/org/juanitodread/conwaygameoflife/MainApp.scala
@@ -37,7 +37,7 @@ object MainApp extends LazyLogging {
   def main(args: Array[String]): Unit = {
     SwingUtilities.invokeLater(new Runnable {
       def run {
-        logger.info("Starting the application...")
+        logger.info("Starting application...")
         ApplicationView().startup(args)
         logger.info("Application started :D")
       }

--- a/src/main/scala/org/juanitodread/conwaygameoflife/util/MessageUtil.scala
+++ b/src/main/scala/org/juanitodread/conwaygameoflife/util/MessageUtil.scala
@@ -41,5 +41,21 @@ object MessageUtil extends ApplicationConstants with LazyLogging {
     case Some(x) => messages.getString(x)
     case None => MessageNotFound
   }
+}
 
+object Messages {
+  final val AppTitle = MessageUtil.getMessage(MessageUtil.AppTitle)
+  final val AppVersion = MessageUtil.getMessage(MessageUtil.AppVersion)
+  final val AppAuthor = MessageUtil.getMessage(MessageUtil.AppAuthor)
+  final val AppYear = MessageUtil.getMessage(MessageUtil.AppYear)
+
+  final val StartButton = MessageUtil.getMessage(MessageUtil.StartButton)
+  final val StopButton = MessageUtil.getMessage(MessageUtil.StopButton)
+  final val ClearButton = MessageUtil.getMessage(MessageUtil.ClearButton)
+  final val AboutButton = MessageUtil.getMessage(MessageUtil.AboutButton)
+
+  final val GenerationsLabel = MessageUtil.getMessage(MessageUtil.GenerationsLabel)
+
+  final val AboutDialog = s"${Messages.AppTitle} - ${Messages.AppVersion}\n\n${Messages.AppAuthor} - ${Messages.AppYear}"
+  final val AppFullTitle = s"${Messages.AppTitle} - ${Messages.AppVersion}"
 }

--- a/src/main/scala/org/juanitodread/conwaygameoflife/view/ApplicationView.scala
+++ b/src/main/scala/org/juanitodread/conwaygameoflife/view/ApplicationView.scala
@@ -18,26 +18,17 @@
  */
 package org.juanitodread.conwaygameoflife.view
 
-import javax.swing.{
-  SwingUtilities,
-  UIManager
-}
-
+import javax.swing.{ SwingUtilities, UIManager }
 import scala.swing._
 import scala.swing.BorderPanel.Position._
 import scala.swing.event._
 import scala.concurrent._
-
 import com.typesafe.scalalogging._
-
 import org.juanitodread.conwaygameoflife.model.Board
-import org.juanitodread.conwaygameoflife.model.cell.{
-  Cell,
-  State
-}
+import org.juanitodread.conwaygameoflife.model.cell.{ Cell, State }
+import org.juanitodread.conwaygameoflife.util.Messages
 
 import scala.language.reflectiveCalls
-
 import ExecutionContext.Implicits.global
 
 /**
@@ -130,13 +121,13 @@ class ApplicationView(val boardSize: Int) extends SimpleSwingApplication with La
 
   //   Panels
   val leftPanel = new BoxPanel(Orientation.Vertical) {
-    preferredSize = new Dimension(75, 600)
+    preferredSize = new Dimension(100, 600)
     border = Swing.EmptyBorder(5, 5, 0, 0)
 
-    val startBtn = ApplicationView.buildButton("start", "Start")
-    val stopBtn = ApplicationView.buildButton("stop", "Stop")
-    val clearBtn = ApplicationView.buildButton("clear", "Clear")
-    val aboutBtn = ApplicationView.buildButton("about", "About")
+    val startBtn = ApplicationView.buildButton("start", Messages.StartButton)
+    val stopBtn = ApplicationView.buildButton("stop", Messages.StopButton)
+    val clearBtn = ApplicationView.buildButton("clear", Messages.ClearButton)
+    val aboutBtn = ApplicationView.buildButton("about", Messages.AboutButton)
 
     contents ++= List(
       startBtn,
@@ -147,7 +138,7 @@ class ApplicationView(val boardSize: Int) extends SimpleSwingApplication with La
 
   val southPanel = new FlowPanel(FlowPanel.Alignment.Right)() {
     val generations = new Label {
-      text = "Generations: 0"
+      text = s"${Messages.GenerationsLabel}: 0"
     }
     contents += generations
   }
@@ -164,7 +155,7 @@ class ApplicationView(val boardSize: Int) extends SimpleSwingApplication with La
     var running = false
     var generation = 0
 
-    title = ApplicationView.TitleApp
+    title = Messages.AppFullTitle
 
     contents = mainPanel
 
@@ -202,7 +193,7 @@ class ApplicationView(val boardSize: Int) extends SimpleSwingApplication with La
 
             refreshGraphicBoard(nextState)
             generation += 1
-            southPanel.generations.text = s"Generations: $generation"
+            southPanel.generations.text = s"${Messages.GenerationsLabel}: ${generation}"
 
             logger.info(southPanel.generations.text)
             Thread.sleep(ApplicationView.TimeSleep)
@@ -224,14 +215,14 @@ class ApplicationView(val boardSize: Int) extends SimpleSwingApplication with La
         logger.info("Clear button clicked")
 
         generation = 0
-        southPanel.generations.text = s"Generations: $generation"
+        southPanel.generations.text = s"${Messages.GenerationsLabel}: ${generation}"
         state.reset()
         refreshGraphicBoard(state)
       }
       case ButtonClicked(component) if component == leftPanel.aboutBtn => {
         logger.info("About button clicked")
 
-        Dialog.showMessage(this, "Conway's game of life in Scala\n\n@juanitodread - 2015 - v1.2.0")
+        Dialog.showMessage(this, Messages.AboutDialog, Messages.AboutButton)
       }
     }
     size = new Dimension(800, 600)
@@ -242,8 +233,6 @@ class ApplicationView(val boardSize: Int) extends SimpleSwingApplication with La
 }
 
 object ApplicationView {
-
-  final val TitleApp = "Conway's Game of Life"
   final val DefaultBoardSize = 50
   final val TimeSleep = 1 * 100
 
@@ -253,7 +242,7 @@ object ApplicationView {
     new Button {
       name = id
       text = label
-      maximumSize = new Dimension(70, 25)
+      maximumSize = new Dimension(100, 25)
       minimumSize = maximumSize
     }
   }


### PR DESCRIPTION
Now messages in the application are defined in properties files to support i18n. i18n works based on the locale of the machine where the application is running.

Default language is English:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/1304670/135731950-60c71761-8411-4de5-bab5-341a713f5004.png">

Spanish is also supported:
<img width="803" alt="image" src="https://user-images.githubusercontent.com/1304670/135732026-5a2cf8b0-6474-4669-8870-df4cc5c773ae.png">